### PR TITLE
First Person View

### DIFF
--- a/RayTrace/Src/Application/application.cpp
+++ b/RayTrace/Src/Application/application.cpp
@@ -76,6 +76,7 @@ void Application::init(Application::Settings& settings)
 	cameraInfo.sensitivity  = 0.5f;
 	cameraInfo.windowHeight = m_swapchain.getExtent().height;
 	cameraInfo.windowWidth  = m_swapchain.getExtent().width;
+	cameraInfo.window = m_window;
 	m_camera.init(cameraInfo);
 
 	// Pipeline
@@ -478,7 +479,6 @@ void Application::pollEvents()
 			{
 				auto mouseMoveEvent = dynamic_cast<MouseMoveEvent*>(event.get());
 				// APP_LOG_TRACE(mouseMoveEvent->eventString());
-
 				m_camera.onMouseMove(*mouseMoveEvent);
 				break;
 			}

--- a/RayTrace/Src/Application/camera.cpp
+++ b/RayTrace/Src/Application/camera.cpp
@@ -12,6 +12,8 @@ void Camera::init(Camera::CreateInfo& info)
 	m_width  = info.windowWidth;
 	m_height = info.windowHeight;
 
+	m_window = info.window;
+
 	// Set view matrix
 	updateViewMatrix();
 
@@ -55,7 +57,7 @@ void Camera::onMouseRelease(MouseReleaseEvent event)
 
 void Camera::onMouseMove(MouseMoveEvent event)
 {
-	if (!m_leftMouse && !m_rightMouse)
+	if (!m_leftMouse && !m_rightMouse && m_cameraMode == CameraMode::STATIONARY)
 	{
 		// No action, just update the mouse position
 		m_mousePos.x = static_cast<float>(event.xPos);
@@ -68,11 +70,15 @@ void Camera::onMouseMove(MouseMoveEvent event)
 	float deltaY = float(event.yPos - m_mousePos.y) / float(m_height);
 
 	// Update camera
-	if (m_leftMouse)
+	if (m_leftMouse && m_cameraMode == CameraMode::STATIONARY)
 		orbit(deltaX, deltaY);
 
-	else if (m_rightMouse)
+	else if (m_rightMouse && m_cameraMode == CameraMode::STATIONARY)
 		dolly(deltaX, deltaY);
+
+	else if (m_cameraMode == CameraMode::FPV)
+		//updateDirection(deltaX, deltaY);
+		orbit(deltaX, deltaY);
 
 	updateViewMatrix();
 
@@ -81,42 +87,135 @@ void Camera::onMouseMove(MouseMoveEvent event)
 	m_mousePos.y = static_cast<float>(event.yPos);
 }
 
-void Camera::updatePosition() { // Updates camera position according to 
-	if (m_wKey) APP_LOG_INFO("W Key Down");
-	if (m_aKey) APP_LOG_INFO("A Key Down");
-	if (m_sKey) APP_LOG_INFO("S Key Down");
-	if (m_dKey) APP_LOG_INFO("D Key Down");
-
-
-	
-}
-
 void Camera::resetPosition()
 {
-	m_eye = { 0.0f, 0.0f, 0.0f };
-}
-
-void Camera::flyMode()
-{
-	m_cameraMode = CameraMode::FLY;
+	m_eye = { 0.0f, 0.0f, 6.0f };
+	m_center = { 0.0f, 0.0f, 0.0f };
+	m_up = { 0.0f, 1.0f, 0.0f };
 }
 
 void Camera::onKeyPress(KeyPressEvent event)
 {
-	if      (event.key == GLFW_KEY_W) m_wKey = true;
-	else if (event.key == GLFW_KEY_A) m_aKey = true;
-	else if (event.key == GLFW_KEY_S) m_sKey = true;
-	else if (event.key == GLFW_KEY_D) m_dKey = true;
+	switch (event.key)
+	{
+		case GLFW_KEY_W: m_wKey = true; break;
+		case GLFW_KEY_A: m_aKey = true; break;
+		case GLFW_KEY_S: m_sKey = true; break;
+		case GLFW_KEY_D: m_dKey = true; break;
+		case GLFW_KEY_LEFT_SHIFT: m_lShift = true; break;
+		case GLFW_KEY_SPACE: m_space = true; break;
+	}
 }
 
 void Camera::onKeyRelease(KeyReleaseEvent event)
 {
-	if      (event.key == GLFW_KEY_W) m_wKey = false;
-	else if (event.key == GLFW_KEY_A) m_aKey = false;
-	else if (event.key == GLFW_KEY_S) m_sKey = false;
-	else if (event.key == GLFW_KEY_D) m_dKey = false;
+	switch (event.key)
+	{
+		case GLFW_KEY_W: m_wKey = false; break;
+		case GLFW_KEY_A: m_aKey = false; break;
+		case GLFW_KEY_S: m_sKey = false; break;
+		case GLFW_KEY_D: m_dKey = false; break;
+		case GLFW_KEY_LEFT_SHIFT: m_lShift = false; break;
+		case GLFW_KEY_SPACE: m_space = false; break;
+		case GLFW_KEY_ESCAPE: // Will likely change keybinds later on. 
+			// Switches between fly mode and stationary mode. 
+			if (m_cameraMode == CameraMode::STATIONARY) FPVMode();
+			else if (m_cameraMode == CameraMode::FPV) stationaryMode();
+			break;
+	}
 }
 
+void Camera::FPVMode()
+{
+	glfwSetInputMode(m_window.getWindowGLFW(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+	m_cameraMode = CameraMode::FPV;
+}
+
+void Camera::stationaryMode()
+{
+	glfwSetInputMode(m_window.getWindowGLFW(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+	m_cameraMode = CameraMode::STATIONARY;
+	resetPosition();
+	updateViewMatrix();
+	m_firstMouseMove = true;
+}
+
+void Camera::updatePosition() {
+
+	if (m_cameraMode == CameraMode::STATIONARY) return;
+
+	m_currentFrame = glfwGetTime(); // Computes the change in time
+	float deltaT = m_currentFrame - m_lastFrame;
+	m_lastFrame = m_currentFrame;
+
+	glm::vec3 axisZ = glm::normalize(m_eye - m_center); // Normalized Z-axis relative to camera (Direction camera is looking)
+	glm::vec3 axisX = glm::normalize(glm::cross(m_up, axisZ)); // Normalized X-axis relative to camera
+
+	const float cameraSpeed = 3.0f * deltaT;
+
+	if (m_wKey) {
+		//APP_LOG_INFO("W Key Down");
+		m_eye -= cameraSpeed * axisZ; // Moves camera position forwards (Z-axis represents forward and backwards for camera)
+	}
+	if (m_aKey) {
+		//APP_LOG_INFO("A Key Down");
+		m_eye -= cameraSpeed * axisX; // Moves camera to the left (X-axis represents left and right of camera)
+		m_center -= cameraSpeed * axisX; // Moves point that camera is looking at to the left
+	}
+	if (m_sKey) {
+		//APP_LOG_INFO("S Key Down");
+		m_eye += cameraSpeed * axisZ; // Moves camera position backwards (Z-axis represents forward and backwards of camera)
+	}
+	if (m_dKey) {
+		//APP_LOG_INFO("D Key Down");
+		m_eye += cameraSpeed * axisX; // Moves camera to the right (X-axis represents left and right of camera)
+		m_center += cameraSpeed * axisX; // Moves point that camera is looking at to the right
+	}
+	if (m_lShift) {
+		//APP_LOG_INFO("Left-Shift Key Down");
+		m_eye -= cameraSpeed * m_worldUp; // Moves camera down
+		m_center -= cameraSpeed * m_worldUp;
+	}
+	if (m_space) {
+		//APP_LOG_INFO("Space Key Down"); 
+		m_eye += cameraSpeed * m_worldUp; // Moves camera up
+		m_center += cameraSpeed * m_worldUp;
+	}
+	updateViewMatrix();
+
+
+}
+
+void Camera::updateDirection(float deltaX, float deltaY)
+{
+	float sensitivity = 5.0f;
+
+	if (m_firstMouseMove) {
+
+	}
+	
+	deltaX *= sensitivity;
+	deltaY *= sensitivity * -1;
+
+	m_yaw += deltaX;
+	m_pitch += deltaY;
+
+	if (m_pitch > 89.0f)
+		m_pitch = 89.0f; // Stops camera from going too far up
+
+	if (m_pitch < -89.0f)
+		m_pitch = -89.0f; // Stops camera from going too far down
+
+	glm::vec3 direction;
+	direction.x = cos(glm::radians(m_yaw)) * cos(glm::radians(m_pitch));
+	direction.y = sin(glm::radians(m_pitch));
+	direction.z = sin(glm::radians(m_yaw)) * cos(glm::radians(m_pitch));
+	m_center = m_eye + glm::normalize(direction);
+	
+	glm::vec3 axisZ = glm::normalize(m_eye - m_center);
+	glm::vec3 axisX = glm::normalize(glm::cross(m_up, axisZ));
+	//m_up = glm::normalize(glm::cross(axisZ, axisX));
+}
 
 void Camera::orbit(float deltaX, float deltaY)
 {
@@ -145,8 +244,15 @@ void Camera::orbit(float deltaX, float deltaY)
 	if (glm::sign(rotationXVec.x) == glm::sign(centerToEye.x) && glm::sign(rotationXVec.z) == glm::sign(centerToEye.z))
 		centerToEye = rotationXVec;
 
-	centerToEye *= radius;
-	m_eye = centerToEye + m_center;
+	if (m_cameraMode == CameraMode::STATIONARY) 
+	{
+		centerToEye *= radius;
+		m_eye = centerToEye + m_center;
+	}
+	else if (m_cameraMode == CameraMode::FPV)
+	{
+		m_center = m_eye + centerToEye;
+	}
 }
 
 void Camera::dolly(float deltaX, float deltaY)

--- a/RayTrace/Src/Application/camera.h
+++ b/RayTrace/Src/Application/camera.h
@@ -6,12 +6,15 @@
 
 #include "logging.h"
 #include "event.h"
+#include "window.h"
 
-enum class CameraMode
+enum class CameraMode // Makes adding new camera modes easy
 {
 	NONE = 0,
-	FLY, STATIONARY
+	FPV, STATIONARY
 };
+
+//cameraInfo.position = { 0.0f, 0.0f, 6.0f }; Initial
 
 class Camera
 {
@@ -28,6 +31,8 @@ public:
 
 		uint32_t windowWidth  = 0;
 		uint32_t windowHeight = 0;
+
+		Window window;
 	};
 
 	void init(Camera::CreateInfo& info);
@@ -38,8 +43,6 @@ public:
 	const float getFov() const { return m_fov; }
 
 	void updatePosition();
-	void resetPosition();
-	void flyMode();
 
 
 	void setWindowSize(uint32_t width, uint32_t height);
@@ -66,10 +69,19 @@ private:
 	float m_fov         = 45.0f;
 	float m_sensitivity = 1.0f;
 
+	float m_yaw = -90.0f;
+	float m_pitch = 0.0f;
+
 	uint32_t m_width  = 0;
 	uint32_t m_height = 0;
 
-	CameraMode m_cameraMode;
+	CameraMode m_cameraMode = CameraMode::STATIONARY;
+	Window m_window;
+
+	float m_currentFrame = 0;
+	float m_lastFrame = 0;
+
+	bool m_firstMouseMove = true;
 
 	// Input state
 	bool m_leftMouse     = false;
@@ -79,10 +91,17 @@ private:
 	bool m_aKey          = false;
 	bool m_sKey          = false;
 	bool m_dKey          = false;
+	bool m_lShift        = false;
+	bool m_space         = false;
+
 	glm::vec2 m_mousePos = { 0.0f, 0.0f };
 
 	void updateViewMatrix() { m_view = glm::lookAt(m_eye, m_center, m_up); }
 
+	void FPVMode();
+	void stationaryMode();
 	void orbit(float deltaX, float deltaY);
 	void dolly(float deltaX, float deltaY);
+	void resetPosition();
+	void updateDirection(float deltaX, float deltaY);
 };

--- a/RayTrace/Src/Application/camera.h
+++ b/RayTrace/Src/Application/camera.h
@@ -14,7 +14,6 @@ enum class CameraMode // Makes adding new camera modes easy
 	FPV, STATIONARY
 };
 
-//cameraInfo.position = { 0.0f, 0.0f, 6.0f }; Initial
 
 class Camera
 {
@@ -69,9 +68,6 @@ private:
 	float m_fov         = 45.0f;
 	float m_sensitivity = 1.0f;
 
-	float m_yaw = -90.0f;
-	float m_pitch = 0.0f;
-
 	uint32_t m_width  = 0;
 	uint32_t m_height = 0;
 
@@ -80,8 +76,6 @@ private:
 
 	float m_currentFrame = 0;
 	float m_lastFrame = 0;
-
-	bool m_firstMouseMove = true;
 
 	// Input state
 	bool m_leftMouse     = false;

--- a/RayTrace/Src/Application/entry.cpp
+++ b/RayTrace/Src/Application/entry.cpp
@@ -8,7 +8,7 @@ int main()
 	Application::Settings settings{};
 	settings.windowWidth    = 800;
 	settings.windowHeight   = 600;
-	settings.framesInFlight = 3;
+	settings.framesInFlight = 2;
 	settings.vSync          = true;
 	settings.cpuRaytracing  = false;
 

--- a/RayTrace/Src/Application/entry.cpp
+++ b/RayTrace/Src/Application/entry.cpp
@@ -8,7 +8,7 @@ int main()
 	Application::Settings settings{};
 	settings.windowWidth    = 800;
 	settings.windowHeight   = 600;
-	settings.framesInFlight = 2;
+	settings.framesInFlight = 3;
 	settings.vSync          = true;
 	settings.cpuRaytracing  = false;
 

--- a/RayTrace/Src/Application/event.cpp
+++ b/RayTrace/Src/Application/event.cpp
@@ -46,10 +46,17 @@ std::string MouseMoveEvent::eventString() const
 std::string KeyPressEvent::eventString() const
 {
 	std::string keyStr;
-	if      (key == GLFW_KEY_W)  keyStr = "W";
-	else if (key == GLFW_KEY_A)  keyStr = "A";
-	else if (key == GLFW_KEY_S)  keyStr = "S";
-	else if (key == GLFW_KEY_D)  keyStr = "D";
+
+	switch (key)
+	{
+		case GLFW_KEY_W: keyStr = "W"; break;
+		case GLFW_KEY_A: keyStr = "A"; break;
+		case GLFW_KEY_S: keyStr = "S"; break;
+		case GLFW_KEY_D: keyStr = "D"; break;
+		case GLFW_KEY_ESCAPE: keyStr = "Escape"; break;
+		case GLFW_KEY_LEFT_SHIFT: keyStr = "Left Shift"; break;
+		case GLFW_KEY_SPACE: keyStr = "Space"; break;
+	}
 
 	std::stringstream ss;
 	ss << "Key Press - " << keyStr;
@@ -59,10 +66,17 @@ std::string KeyPressEvent::eventString() const
 std::string KeyReleaseEvent::eventString() const
 {
 	std::string keyStr;
-	if      (key == GLFW_KEY_W)  keyStr = "W";
-	else if (key == GLFW_KEY_A)  keyStr = "A";
-	else if (key == GLFW_KEY_S)  keyStr = "S";
-	else if (key == GLFW_KEY_D)  keyStr = "D";
+
+	switch (key)
+	{
+		case GLFW_KEY_W: keyStr = "W"; break;
+		case GLFW_KEY_A: keyStr = "A"; break;
+		case GLFW_KEY_S: keyStr = "S"; break;
+		case GLFW_KEY_D: keyStr = "D"; break;
+		case GLFW_KEY_ESCAPE: keyStr = "Escape"; break;
+		case GLFW_KEY_LEFT_SHIFT: keyStr = "Left Shift"; break;
+		case GLFW_KEY_SPACE: keyStr = "Space"; break;
+	}
 
 	std::stringstream ss;
 	ss << "Key Release - " << keyStr;

--- a/RayTrace/Src/Application/window.cpp
+++ b/RayTrace/Src/Application/window.cpp
@@ -83,7 +83,8 @@ void Window::cursorPositionCallback(GLFWwindow* window, double xpos, double ypos
 }
 
 void Window::keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-	std::vector<int> keys = { GLFW_KEY_W, GLFW_KEY_A, GLFW_KEY_S, GLFW_KEY_D }; // Keys to care about
+	std::vector<int> keys = { GLFW_KEY_W, GLFW_KEY_A, GLFW_KEY_S, GLFW_KEY_D, GLFW_KEY_ESCAPE, 
+	GLFW_KEY_LEFT_SHIFT, GLFW_KEY_SPACE }; // Keys to care about
 	for (int i = 0; i < keys.size(); i++) //Loops through keys to find match
 	{
 		if (key == keys[i] && action == GLFW_PRESS) // Key press


### PR DESCRIPTION
Implemented First Person View. It allows for free movement through the scene. There are currently two camera types: FPV and Stationary. Stationary mode puts you at a fixed position with dolly and orbit movement like before. 

Current keybinds:

WASD: Allows for movement like any game
Left-Shift: Moves downward
Spacebar: Moves upward
Esc: Switches between stationary and FPV. 

One thing I might change is how the W and S keys work. Currently, if you press W or S, it moves you in the direction that you are looking; i.e., the camera's z-axis. I'm thinking of changing it so it moves you along the world's xz-plane so it would behave similar to Minecraft's creative mode.

I would appreciate any feedback. 