### PR TITLE
Ground Detection

### DIFF
--- a/RayTrace/Src/Application/Gui.cpp
+++ b/RayTrace/Src/Application/Gui.cpp
@@ -79,24 +79,29 @@ void Gui::beginUI()
 	ImVec2 window_pos = ImVec2(screenSize.x - window_size.x, heightOffset);
 
 	// Set the UI window size.
-	ImVec2 window_size = ImVec2(300, 300);
+	//ImVec2 window_size = ImVec2(300, 300);
 
 	// Set position of the Ui to the top right corner
 	// x is the screen width minus the window width to align to the right, Y is 0 to align to the top.
-	ImVec2 window_pos = ImVec2(screenSize.x - window_size.x, 0); 
+	//ImVec2 window_pos = ImVec2(screenSize.x - window_size.x, 0); 
 
 
 	// Apply the calculated position and size to the next window (the "Settings" window).
 	// ImGuiCond_Always means this size setting will be applied every time without any conditions.
 	ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always);
 	ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
+	// bool demo = true;
+
+	// ImGui::ShowDemoWindow(&demo);
 
 	{
 
 		// Creating the settings window 
 		// ImGuiWindowFlags_NoResize prevents the user from resizing the window. 
 
-		ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoResize);
+		//ImGui::Begin("Settings", nullptr, ImGuiWindowFlags_NoResize);
+
+		ImGui::Begin("Settings");
 
 		// Debug settings
 		if (ImGui::CollapsingHeader("Debug"))
@@ -136,13 +141,16 @@ void Gui::beginUI()
 		{
 			m_state.changed |= ImGui::SliderFloat("Camera Sensitivity", &m_state.sensitivity, 0.0f, 2.0f);
 			m_state.changed |= ImGui::SliderFloat("Camera Speed", &m_state.speed, 0.0f, 6.0f);
-			ImGui::Text("Camera Modes:"); ImGui::SameLine();
-			m_state.changed |= ImGui::RadioButton("Stationary", &m_state.mode, 0); ImGui::SameLine();
+			m_state.changed |= ImGui::InputFloat("Ground Height", &m_state.ground, 0.01f, 1.0f, "%.3f");
+		 
+			ImGui::SeparatorText("Camera Modes");
+			m_state.changed |= ImGui::RadioButton("Stationary", &m_state.mode, 0); 
 			m_state.changed |= ImGui::RadioButton("First Person View (FPV)", &m_state.mode, 1);
 
-			if (ImGui::Button("Save Camera Position")) { m_state.cameraSaves++; }
+			ImGui::SeparatorText("Camera Positions");
+			if (ImGui::Button("Save Position")) { m_state.cameraSaves++; }
 
-			ImGui::Text("Switch Camera: ");
+			ImGui::Text("Switch Position: ");
 			ImGui::SameLine();
 			if (m_state.changed = ImGui::ArrowButton("##left", ImGuiDir_Left)) { m_state.currentCamera--; } //** If statement valid?
 			ImGui::SameLine();

--- a/RayTrace/Src/Application/Gui.h
+++ b/RayTrace/Src/Application/Gui.h
@@ -126,6 +126,7 @@ public:
 		// Camera
 		float sensitivity   = 1.0f;
 		float speed         = 3.0f;
+		float ground        = 0.0f;
 		int   mode          = 0;
 		int   cameraSaves   = 0;
 		int   currentCamera = 0;

--- a/RayTrace/Src/Application/camera.h
+++ b/RayTrace/Src/Application/camera.h
@@ -47,6 +47,7 @@ public:
 	void updateSensitivity(float newSense) { m_sensitivity = newSense; };
 	void updateSpeed(float newSpeed) { m_speed = newSpeed; }
 	void updateMode(int mode);
+	void updateGround(float ground);
 	void saveCamera(int cameraSaves);
 	void switchCameras(int currentCamera);
 
@@ -72,6 +73,7 @@ private:
 	std::vector<glm::vec3> m_eyePositions;
 	std::vector<glm::vec3> m_centerPositions;
 
+	float m_ground = 0.0f;
 
 	float m_nearPlane   = 0.01f;
 	float m_farPlane    = 100.0f;
@@ -97,6 +99,7 @@ private:
 	bool m_lShift        = false;
 	bool m_space         = false;
 	bool m_mousePause    = false;
+	bool m_lCtrl         = false;
 
 	int m_cameraSaves = 0;
 	int m_currentIndex = 0;

--- a/RayTrace/Src/Application/entry.cpp
+++ b/RayTrace/Src/Application/entry.cpp
@@ -8,7 +8,7 @@ int main()
 	Application::Settings settings{};
 	settings.windowWidth    = 800;
 	settings.windowHeight   = 600;
-	settings.framesInFlight = 3;
+	settings.framesInFlight = 2;
 	settings.vSync          = false;
 	settings.cpuRaytracing  = false;
 	settings.useRtx         = false;

--- a/RayTrace/Src/Application/entry.cpp
+++ b/RayTrace/Src/Application/entry.cpp
@@ -8,7 +8,7 @@ int main()
 	Application::Settings settings{};
 	settings.windowWidth    = 800;
 	settings.windowHeight   = 600;
-	settings.framesInFlight = 2;
+	settings.framesInFlight = 3;
 	settings.vSync          = false;
 	settings.cpuRaytracing  = false;
 	settings.useRtx         = true;

--- a/RayTrace/Src/Application/window.cpp
+++ b/RayTrace/Src/Application/window.cpp
@@ -85,7 +85,7 @@ void Window::cursorPositionCallback(GLFWwindow* window, double xpos, double ypos
 void Window::keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
 	std::vector<int> keys = { 
 		GLFW_KEY_W, GLFW_KEY_A, GLFW_KEY_S, GLFW_KEY_D, GLFW_KEY_U,
-		GLFW_KEY_ESCAPE, GLFW_KEY_LEFT_SHIFT, GLFW_KEY_SPACE }; // Keys to care about
+		GLFW_KEY_ESCAPE, GLFW_KEY_LEFT_SHIFT, GLFW_KEY_SPACE, GLFW_KEY_LEFT_CONTROL }; // Keys to care about
 
 	for (int i = 0; i < keys.size(); i++) //Loops through keys to find match
 	{

--- a/RayTrace/Src/Core/renderer.cpp
+++ b/RayTrace/Src/Core/renderer.cpp
@@ -325,6 +325,7 @@ void Renderer::updateUI()
 	m_camera->updateMode(m_ui.mode);
 	m_camera->saveCamera(m_ui.cameraSaves);
 	m_camera->switchCameras(m_ui.currentCamera);
+	m_camera->updateGround(m_ui.ground);
 
 	// Debug
 	ubo.debugMode = (int)m_ui.debugMode;


### PR DESCRIPTION
Added ground collision. When you hit the ground, you are locked to it and can't fly back up except with the space bar. Since we don't have a well defined ground in the scenes, the ground height is customizable in the GUI. The camera's height will be adjusted accordingly when changing the ground height. 

Also made some slight changes in the GUI layout for the camera settings. 